### PR TITLE
Use `.Site.RegularPages` to support changes in Hugo 0.58.0

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
 		{{ end }}
 
 		<ul class="posts">
-			{{- range .Data.Pages -}}
+			{{- range .Site.RegularPages -}}
 			{{- if (in (.Site.Params.excludedTypes | default (slice "page")) .Type) -}}
 			{{- else -}}
 			<li class="post">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
 			</h2>
 			<div class="posts">
 				{{- $.Scratch.Set "counter" 0 -}}
-				{{- range .Data.Pages -}}
+				{{- range .Site.RegularPages -}}
 				{{- if (in (.Site.Params.excludedTypes | default (slice "page")) .Type) -}}
 				{{- else -}}
 				{{- if lt ($.Scratch.Get "counter") (.Site.Params.RecentPostsCount | default 10) -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <div class="footer wrapper">
 	<nav class="nav">
-		<div><a href="https://github.com/vividvilla/ezhil">Ezhil theme</a> | Built with <a href="https://gohugo.io">Hugo</a></div>
+		<div><a href="https://github.com/gavincabbage/ezhil">Ezhil theme</a> | Built with <a href="https://gohugo.io">Hugo</a></div>
 	</nav>
 </div>
 


### PR DESCRIPTION
This PR updates the loops in the list and index pages to use `.Site.RegularPages` in place of `.Data.Pages` to support behaviorial changes in Hugo 0.58.0, as described in the following warning while running `hugo -D`:

```
WARN 2019/09/03 22:49:11 In the next Hugo version (0.58.0) we will change how $home.Pages behaves. If you want to list all regular pages, replace .Pages or .Data.Pages with .Site.RegularPages in your home page template.
```

PS- Thanks for the theme, it's really great and I am using on my personal site.