### PR TITLE
feat: Add custom CSS overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ paginate = 10
     disableDisqusTypes = ["page"]
     # If social media links are enabled then enable this to fetch icons from CDN instead of hosted on your site.
     featherIconsCDN = true
+	# Path to custom CSS overrides. (Optional).
+	customCSS = ["/path/to/my.css"]
 
 # Main menu which appears below site header.
 [[menu.main]]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,6 +15,7 @@ disqusShortname = "localhost"
 	subtitle = "Clean and minimal personal [blog theme for Hugo](https://github.com/vividvilla/ezhil)"
 	disableDisqusTypes = ["page"]
 	featherIconsCDN = true
+	# customCSS = ["css/mycustom.css"]
 
 [[menu.main]]
 name = "Home"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,7 +20,9 @@
 
 	<link rel="stylesheet" type="text/css" media="screen" href="/css/normalize.css" />
 	<link rel="stylesheet" type="text/css" media="screen" href="/css/main.css" />
-
+	{{ range .Site.Params.customCSS -}}
+		<link rel="stylesheet" href="{{ . | absURL }}">
+	{{- end }}
 	{{- if and (isset .Site.Params "social") (isset .Site.Params "feathericonscdn") (eq .Site.Params.featherIconsCDN true) -}}
 	<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
 	{{- else if (isset .Site.Params "social") -}}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -157,7 +157,7 @@ ul {
     margin-bottom: 0;
 	margin-top: 0;
 	padding: 20px;
-	background-color: #FAFAFA !important;
+	/* background-color: #FAFAFA !important; */
 }
 
 .highlight {


### PR DESCRIPTION
Adds a `Site.params.customCSS` to load custom CSS files (_after_ the `main.css` loads) for overriding defaults.