### PR TITLE
feat: allow specifying favicon via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ paginate = 10
     disableDisqusTypes = ["page"]
     # If social media links are enabled then enable this to fetch icons from CDN instead of hosted on your site.
     featherIconsCDN = true
+    # Specify favicon (icons/i.png maps to static/icons/i.png). No favicon if not defined.
+    favicon = "icons/myicon.png"
 
 # Main menu which appears below site header.
 [[menu.main]]

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,6 +9,10 @@
 	<title>{{ $title }} - {{ $siteTitle }}</title>
 	{{- end -}}
 
+	{{- if isset .Site.Params "favicon" -}}
+	<link rel="icon" type="image/png" href={{ .Site.Params.favicon }} />
+	{{- end -}}
+
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	{{ with .OutputFormats.Get "rss" -}}
 	{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
We assume PNG MIME type, because, from my understanding, PNG is the main format
for favicons nowadays (even if they have an "ico" extension). Further
configuration options are needed to allow for specifying different MIME types.