### PR TITLE
feat: add copyright option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ languageCode = "en-us"
 title = "My personal blog"
 theme = "ezhil"
 
+copyright = "© Copyright notice"
+
 # Enable syntax highlighting.
 pygmentsstyle = "vs"
 pygmentscodefences = true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,6 +4,8 @@ title = "Ezhil"
 theme = "ezhil"
 paginate = 5
 
+copyright = "© Copyright notice"
+
 pygmentsstyle = "vs"
 pygmentscodefences = true
 pygmentscodefencesguesssyntax = true

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <div class="footer wrapper">
 	<nav class="nav">
-		<div><a href="https://github.com/vividvilla/ezhil">Ezhil theme</a> | Built with <a href="https://gohugo.io">Hugo</a></div>
+		<div>{{ with .Site.Copyright }} {{ . }} | {{ end }} <a href="https://github.com/vividvilla/ezhil">Ezhil theme</a> | Built with <a href="https://gohugo.io">Hugo</a></div>
 	</nav>
 </div>
 


### PR DESCRIPTION
The small feature allows and adopter of the theme to be able to add their own copyright notice. 
The `.Site.Copyright` is built in to Hugo.