### PR TITLE
feat: add tweet or share post functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ paginate = 10
     # `static/js` folder and specify path here as `js/script-name.js`.
     customJS = ["js/abc.js", "js/xyz.js"]
 
+    # Specify if you want to add a 'share' and 'tweet' this post link at the bottom of every post
+    sharePost = true  # or false (default)
+
+
 # Main menu which appears below site header.
 [[menu.main]]
 name = "Home"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,7 @@ disqusShortname = "ezhil-demo"
 	# customCSS = "css/custom.css"  # Custom CSS applied to default styles.
 	# customDarkCSS = "css/custom-dark.css"  # Custom styles applied to dark mode css.
 	# customJS = ["js/custom.js", "js/custom1.js"]  # Custom JS scripts.
+	sharePost = true
 
 [[menu.main]]
 name = "Home"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,6 +28,19 @@
 			{{ end }}
 		</div>
 
+		{{- if ne .Type "page" -}}
+			{{- if (eq .Site.Params.sharePost true) -}}
+			<div class="post-share">
+				If this article was helpful 
+				<a onclick="window.open({{ printf "https://twitter.com/share?text=%s&amp;url=%s" .Title .Permalink }}, 'share-twitter', 'width=550,height=235');return false;">tweet it</a>
+				or 
+				<a onclick="window.open({{ printf "https://www.facebook.com/sharer/sharer.php?u=%s" .Permalink }}, 'share-facebook', 'width=580,height=296')">share it</a>.
+			</div>
+			{{- end -}}
+		{{- end -}}
+
+
+
 		{{- $.Scratch.Set "isDisqus" true -}}
 
 		{{- if and (isset .Params "type") (in .Site.Params.disableDisqusTypes .Params.type) -}}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -6,6 +6,10 @@ body {
     font-size: 16px;
 }
 
+a:not([href]) {
+    cursor: pointer;
+}
+
 a, a:hover {
     color: #a00;
     text-decoration: none;
@@ -319,6 +323,11 @@ ul {
     font-size: 12px;
     text-decoration: none;
     margin: 0 1px;
+}
+
+.post-share {
+    padding-top: 20px;
+    text-align: center;
 }
 
 .list .posts .post .meta {


### PR DESCRIPTION
When enabled via `[param]sharePost = true` in the site config every post will have a
`If this article was helpful tweet it or share it.` line at the bottom of the post, below the tags.

This allows any reader to share via Twitter or Facebook the title of the article and a link back to the article itself.


