### PR TITLE
[Fix] Link to home in head partial.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <div class="header">
-	<h1 class="site-title"><a href="/">{{ .Site.Title }}</a></h1>
+	<h1 class="site-title"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
 	<div class="site-description">
 		{{- if isset .Site.Params "subtitle" -}}
 		<h2>{{ .Site.Params.Subtitle | markdownify }}</h2>


### PR DESCRIPTION
Link was pointing to / instead of using .Site.BaseURL.