### PR TITLE
Feature: multi language

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,7 +21,7 @@
 			</li>
 			{{ end }}
 			{{ if .IsTranslated }}
-			{{ range .Tranlations }}
+			{{ range .Translations }}
 			<li style="float:right;"><a href="{{ .Permalink }}">{{ .Lang }}</a></li>
 			{{ end }}
 			{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <div class="header">
-	<h1 class="site-title"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
+	<h1 class="site-title"><a href="{{ absLangURL "/" }}">{{ .Site.Title }}</a></h1>
 	<div class="site-description">
 		{{- if isset .Site.Params "subtitle" -}}
 		<h2>{{ .Site.Params.Subtitle | markdownify }}</h2>
@@ -14,11 +14,16 @@
 	</div>
 
 	<nav class="nav">
-		<ul class="flat">
+		<ul class="flat" style="text-align:left;">
 			{{ range .Site.Menus.main }}
 			<li>
-				<a href="{{ .URL }}">{{ .Name }}</a>
+				<a href="{{ .URL | absLangURL }}">{{ .Name }}</a>
 			</li>
+			{{ end }}
+			{{ if .IsTranslated }}
+			{{ range .Tranlations }}
+			<li style="float:right;"><a href="{{ .Permalink }}">{{ .Lang }}</a></li>
+			{{ end }}
 			{{ end }}
 		</ul>
 	</nav>


### PR DESCRIPTION
Dear @vividvilla 

Thank you for this great theme!  But, I think, it is more convenient that the theme can deal with multi language page.  Therefore, I modified following:

### Modify hyperlink of title
When click the site title, we can go to the home of present language.

### Add hyperlink to its translations
When the present article has translations, the link to them will appear on the same line with the menu.

All changes work well on [my web site](https://presche.me), it contains Japanese and English pages (now, it has only home and about page...).  I have just started to use Hugo, and not being familiar with HTML/CSS.  If this PR is silly, please discard.

Thanks,