### PR TITLE
Disable Google Analytics when the site being served with build-in server

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,9 @@
 	</nav>
 </div>
 
+{{ if not .Site.IsServer }}
 {{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
 {{- with .Site.Params.Social -}}
 <script>feather.replace()</script>
 {{- end -}}


### PR DESCRIPTION
Dear vividvilla,

I think, it is better to disable Google Analytics when the site being served with Hugo's build-in server (i.e., when we run `hugo server`).  `.Site.IsServer` is a build-in site variable, please refer to the [docs](https://gohugo.io/variables/site/#site-variables-list) if necessary.

Thanks,