### PR TITLE
replace .RawContent with .Summary - looks way better

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,10 +19,8 @@
 					<span class="description">
 						{{ if isset .Params "description" }}
 						{{ .Description }}
-						{{ else if gt (len .RawContent) 120 }}
-						{{ slicestr .RawContent 0 120 }}...
 						{{ else }}
-						{{ .RawContent }}
+						{{ .Summary }}&hellip;
 						{{ end }}
 					</span>
 				</div>


### PR DESCRIPTION
.Summary retains all formatting of posts for the paginator which looks much nicer than .RawContent. The length of the .Summary (in words, not characters) can be set via the config variable summaryLength.