### PR TITLE
Include front matter in home and list pages if provided

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,6 +12,8 @@
 			<h1 class="page-title">All articles</h1>
 		{{ end }}
 
+		{{ with .Content }}{{ . }}{{ end }}
+
 		<ul class="posts">
 			{{- range .Data.Pages -}}
 			{{- if (in (.Site.Params.excludedTypes | default (slice "page")) .Type) -}}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -6,7 +6,9 @@
 	<div class="container wrapper tags">
 		{{ partial "head.html" . }}
 
-		<h1 class="page-title">All tags</h1>
+		<h1 class="page-title">{{ .Title }}</h1>
+
+		{{ with .Content }}{{ . }}{{ end }}
 
 		{{ $biggest := 1 }}
 		{{ $smallest := 1 }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,6 +5,8 @@
 	<div class="container wrapper">
 		{{ partial "head.html" . }}
 
+		{{ with .Content }}{{ . }}{{ end }}
+
 		<div class="recent-posts section">
 			<h2 class="section-header">
 				Recent posts


### PR DESCRIPTION
Contents in `_index.md` files will be used if the relevant files
exist, per hugo documentation:
https://gohugo.io/templates/lists/#add-content-and-front-matter-to-list-pages