### PR TITLE
render code blocks as inline-block to fix indentation/padding issue

### DIFF
--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -67,3 +67,7 @@ table th, table td {
     padding: 10px 20px;
     border: 1px solid #666;
 }
+
+pre code {
+  display: inline-block
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -191,6 +191,11 @@ ul {
     background-color: #FAFAFA;
 }
 
+pre code {
+  display: inline-block;
+}
+  
+
 .wrapper {
     max-width: 760px;
     margin: 0 auto;


### PR DESCRIPTION
I don't pretend to know how to manipulate front-end at all, but for some reason my code blocks would render with the first line indented. Ex:

![image](https://user-images.githubusercontent.com/1837593/80936831-6824a980-8d98-11ea-9c8f-d7361e4d64ad.png)

You see the first line indented, the second line indentation is expected (that's what I have in my code block), and the following lines are not padded either (I believe there's a default padding on these).

Displaying the `pre code` elements as `inline-block` should fix it whether syntax is highlighted `class=highlight` or not.

The result:

![image](https://user-images.githubusercontent.com/1837593/80936927-b0dc6280-8d98-11ea-8bad-6534347cc127.png)
