### PR TITLE
adding base tag to header to fix static file linking

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,5 @@
 <div class="header">
+	<base href="{{ .Site.BaseURL }}">
 	<h1 class="site-title"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
 	<div class="site-description">
 		{{- if isset .Site.Params "subtitle" -}}


### PR DESCRIPTION
If I specify a baseURL, it seems like my static files don't get linked correctly because of a missing `<base>` tag in the **head.html** partial. This should help resolve that issue based on this [stackoverflow](https://stackoverflow.com/questions/46059869/cannot-link-to-static-files-with-hugo) post.