### PR TITLE
fix footnotes link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<base href="{{ .Permalink }}">
 	{{- $title := ( .Title ) -}}
 	{{- $siteTitle := ( .Site.Title ) -}}
 	{{- if .IsHome -}}


### PR DESCRIPTION
the current foot note links does not work. adding `<base href="{{ .Permalink }}">` to `<head>` fixes this issue.

https://github.com/vividvilla/ezhil/issues/54
